### PR TITLE
add new sectoral FE synfuel/biofuel/fossil fuel reporting 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6718009158'
+ValidationKey: '6719622840'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.161.1
-Date: 2020-11-12
+Version: 36.162.0
+Date: 2020-11-16
 Author@R: Anastasis Giannousakis, Michaja Pehl
 Author: Anastasis Giannousakis <giannou@pik-potsdam.de>
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>


### PR DESCRIPTION
add new FE sectoral synfuel/biomass/fossil reporting (taking into account that the proportion of seliqbio and seliqfos flows may be different across sectors). 
  